### PR TITLE
Merge API prototype

### DIFF
--- a/NexusUnrealSDK/Source/NexusUnrealSDK/Private/NexusPrototype.cpp
+++ b/NexusUnrealSDK/Source/NexusUnrealSDK/Private/NexusPrototype.cpp
@@ -3,6 +3,7 @@
 
 #include "NexusPrototype.h"
 #include "NexusUnrealSDK.h"
+#include "NexusShared.h"
 #include "Http.h"
 #include "HttpManager.h"
 #include "PlatformHttp.h"

--- a/NexusUnrealSDK/Source/NexusUnrealSDK/Public/NexusPrototype.h
+++ b/NexusUnrealSDK/Source/NexusUnrealSDK/Public/NexusPrototype.h
@@ -11,14 +11,6 @@
 
 namespace NexusSDK
 {
-	/** Simple abstract base class that represents the state of a request, should not need a virtual destructor. */
-	class FRequestContext
-	{
-	};
-
-	/** The class above as a unique pointer. */
-	using FRequestContextPtr = TUniquePtr<FRequestContext>;
-
 	/**
 	 * The cat facts API!
 	 * 

--- a/NexusUnrealSDK/Source/NexusUnrealSDK/Public/NexusShared.h
+++ b/NexusUnrealSDK/Source/NexusUnrealSDK/Public/NexusShared.h
@@ -1,0 +1,21 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+/**
+ * Shared stuff between all Nexus interfaces.
+ */
+
+namespace NexusSDK
+{
+	/** Simple abstract base class that represents the state of a request, should not need a virtual destructor. */
+	class FRequestContext
+	{
+	};
+
+	/** The class above as a unique pointer. */
+	using FRequestContextPtr = TUniquePtr<FRequestContext>;
+
+} // namespace NexusSDK

--- a/NexusUnrealSDK/Source/NexusUnrealSDK/Public/NexusUnrealSDK.h
+++ b/NexusUnrealSDK/Source/NexusUnrealSDK/Public/NexusUnrealSDK.h
@@ -5,6 +5,7 @@
 #include "CoreMinimal.h"
 #include "Modules/ModuleManager.h"
 #include "NexusPrototype.h"
+#include "NexusShared.h"
 
 class FNexusUnrealSDKModule : public IModuleInterface
 {


### PR DESCRIPTION
This brings over a few changes from the API prototype branch, mainly because we're expecting to get the generated SDK in here soon.
Moves some definitions to a shared header, and moves the API over to using structs for requests and responses.
The GetCreators API call doesn't correctly decode the json, but we'll be getting rid of it soon anyway.